### PR TITLE
fix: add .qzv output for rep-seqs in step 4 (fixes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You have to link your apptainer image to the option file so Q2Pipe can correctly
 
 ```
 # Modify the APPTAINER_COMMAND= line in optionfile_q2pipe_default.txt
-# You can specify a different temprary folder by adding -B /path/to/your/temp/folder:/tmp before the image path
+# You can specify a different temporary folder by adding -B /path/to/your/temp/folder:/tmp before the image path
 
 APPTAINER_COMMAND="apptainer exec --cleanenv --env MPLCONFIGDIR=/tmp,TMPDIR=/tmp /path/to/your/apptainer_image.sif"
 ```
@@ -70,5 +70,5 @@ Nagati, M., Bergeron, MJ., Gagné, P. et al. Exploring winter diet, gut microbio
 
 Q2Pipe is open-source software released under the **[MIT License](LICENSE)**.
 
-This pipeline was developped at Natural Ressources Canada's Dr. Christine Martineau laboratory
+This pipeline was developed at Natural Resources Canada's Dr. Christine Martineau laboratory
 

--- a/q2pipe_step4_denovo_clustering.sh
+++ b/q2pipe_step4_denovo_clustering.sh
@@ -63,6 +63,9 @@ then
     echo "NA parameter detected, creating necessary files to skip clustering"
     cp -v $ANALYSIS_NAME.table-dada2_minfreq"$p_min_frequency"_minsamp"$p_min_samples".qza $ANALYSIS_NAME.table-dada2_dn"$p_perc_identity".qza
     cp -v $ANALYSIS_NAME.rep-seqs-dada2_minfreq"$p_min_frequency"_minsamp"$p_min_samples".qza $ANALYSIS_NAME.rep-seqs-dada2_dn"$p_perc_identity".qza
+    $APPTAINER_COMMAND qiime feature-table tabulate-seqs \
+    --i-data $ANALYSIS_NAME.rep-seqs-dada2_dn"$p_perc_identity".qza \
+    --o-visualization $ANALYSIS_NAME.rep-seqs-dada2_dn"$p_perc_identity".qzv --verbose
     exit 0
 fi
 
@@ -77,3 +80,7 @@ $APPTAINER_COMMAND qiime vsearch cluster-features-de-novo \
 $APPTAINER_COMMAND qiime feature-table summarize \
 --i-table $ANALYSIS_NAME.table-dada2_dn"$p_perc_identity".qza \
 --o-visualization $ANALYSIS_NAME.table-dada2_dn"$p_perc_identity".qzv --verbose
+
+$APPTAINER_COMMAND qiime feature-table tabulate-seqs \
+--i-data $ANALYSIS_NAME.rep-seqs-dada2_dn"$p_perc_identity".qza \
+--o-visualization $ANALYSIS_NAME.rep-seqs-dada2_dn"$p_perc_identity".qzv --verbose


### PR DESCRIPTION
Closes #24

Add qiime feature-table tabulate-seqs to produce QZV visualization for rep-seqs in clustering step 4. Covers both clustering and NA (skip) modes.

Also fix README typos: temprary->temporary, developped->developed, Ressources->Resources.

Made with [Cursor](https://cursor.com)